### PR TITLE
yield*

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function compose(middleware){
       if (!mw) {
         if (done) throw new Error('middleware yielded control multiple times');
         done = true;
-        return downstream || noop;
+        return downstream || noop();
       }
 
       return mw.call(ctx, next());
@@ -43,6 +43,4 @@ function compose(middleware){
  * @api private
  */
 
-function noop(done){
-  done();
-}
+function *noop(){}

--- a/test.js
+++ b/test.js
@@ -89,6 +89,16 @@ describe('Koa Compose', function(){
     co(compose(stack))(done);
   })
 
+  it('should work when yielding at the end of the stack with yield*', function(done) {
+    var stack = [];
+
+    stack.push(function *(next){
+      yield* next;
+    });
+
+    co(compose(stack))(done);
+  })
+
   it('should keep the context', function(done){
     var ctx = {};
 


### PR DESCRIPTION
use `yield*` internally. `downstream` _must_ be a generator if it exists.
