### PR TITLE
use generator delegation

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function compose(middleware){
     var ctx = this;
     var i = 0;
 
-    yield next();
+    yield *next();
 
     function next(){
       var mw = middleware[i++];


### PR DESCRIPTION
use your dreaded `yield* next` internally. since we assert that all middleware are generator functions, it shouldn't break anything. a lot of people care about performance numbers, and this will raise your benchmark numbers significantly when you have a lot of middleware (though you should use drastically fewer middleware than connect/express, so it's really pointless IMO)
