### PR TITLE
change order of fn name resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -59,13 +58,13 @@ function instrumented(middleware){
   return function *(next){
     var i = middleware.length;
     var prev = next || noop();
-    var name = prev.name || prev._name || 'noop';
+    var name = prev._name || prev.name || 'noop';
     var curr;
 
     while (i--) {
       curr = middleware[i];
       prev = wrap.call(this, curr, prev, name);
-      name = curr.name || curr._name;
+      name = curr._name || curr.name;
     }
 
     yield *prev;


### PR DESCRIPTION
This is to have the same order as koa/lib/application.js:

debug('use %s', fn._name || fn.name || '-');
cf https://github.com/koajs/koa/blob/master/lib/application.js#L83

what is the rationale for you between the 2 version ?

I am working on an "instrumentation" middleware and am trying to see how I can "rename" anonymous or non anonymous middleware so that debug / audit traces are optimally readable.

I don't know why fn._name was there in the first place so I thought it was there for renaming purpose.

I would even prefer something like

```
name = fn._rename || fn.name || fn._name_default || "-"
```

so that you can :
- force a name (_rename)
- add a default name when fn is anonymous

both case are useful depending on the instrumentation. I largely prefer the "rename" case fn._name || fn.name
