### PR TITLE
propagate the composed middleware return

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function compose(middleware){
       prev = curr.call(this, prev);
     }
 
-    yield *prev;
+    return yield *prev;
   }
 }
 


### PR DESCRIPTION
I have a use case where I need to grab the value returned in a middleware chain.
Koa-compose currently breaks the return path.

I hope you will accept this ; currently the composed middleware returns nothing.
