### PR TITLE
async (ctx, next) => await next()

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,9 +38,11 @@ function compose(middleware){
       const fn = middleware[i] || next
       if (!fn) return Promise.resolve()
       try {
-        return Promise.resolve(fn(context, function next() {
+        context.next = next
+        return Promise.resolve(fn(context, next))
+        function next() {
           return dispatch(i + 1)
-        }))
+        }
       } catch(err) {
         return Promise.reject(err);
       }

--- a/index.js
+++ b/index.js
@@ -38,11 +38,9 @@ function compose(middleware){
       const fn = middleware[i] || next
       if (!fn) return Promise.resolve()
       try {
-        context.next = next
-        return Promise.resolve(fn(context, next))
-        function next() {
+        return Promise.resolve(fn(context, function next() {
           return dispatch(i + 1)
-        }
+        }))
       } catch(err) {
         return Promise.reject(err);
       }

--- a/index.js
+++ b/index.js
@@ -29,8 +29,12 @@ function compose(middleware){
    */
 
   return function (context, next) {
+    // last called middleware #
+    let index = -1
     return dispatch(0)
     function dispatch(i) {
+      if (i <= index) throw new Error('next() called multiple times')
+      index = i
       const fn = middleware[i] || next
       if (!fn) return Promise.resolve()
       try {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function compose(middleware){
     let index = -1
     return dispatch(0)
     function dispatch(i) {
-      if (i <= index) throw new Error('next() called multiple times')
+      if (i <= index) return Promise.reject(new Error('next() called multiple times'))
       index = i
       const fn = middleware[i] || next
       if (!fn) return Promise.resolve()

--- a/test/test.js
+++ b/test/test.js
@@ -217,8 +217,8 @@ describe('Koa Compose', function(){
   it('should throw if next() is called multiple times #2', function() {
     return compose([
       co.wrap(function* (ctx, next) {
-        yield next()
-        yield next()
+        yield ctx.next()
+        yield ctx.next()
       }),
       co.wrap(function* (ctx) {
 

--- a/test/test.js
+++ b/test/test.js
@@ -210,4 +210,33 @@ describe('Koa Compose', function(){
       })
     ])({}).then(() => {throw new Error('boom')}, err => {})
   })
+
+  it('should support ctx.next().then()', function(){
+    var arr = [];
+    var stack = [];
+
+    stack.push(function *(ctx){
+      arr.push(1);
+      arr.push(2);
+      yield ctx.next();
+      arr.push(7);
+      arr.push(8);
+    })
+
+    stack.push(function *(ctx){
+      arr.push(3);
+      yield ctx.next();
+      arr.push(6);
+    })
+
+    stack.push(function *(ctx){
+      arr.push(4);
+      yield ctx.next();
+      arr.push(5);
+    })
+
+    return compose(stack.map(co.wrap))({}).then(function () {
+      arr.should.eql([1, 2, 3, 4, 5, 6, 7, 8]);
+    })
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -179,4 +179,26 @@ describe('Koa Compose', function(){
       e.should.be.instanceof(Error)
     })
   })
+
+  // https://github.com/koajs/compose/pull/27#issuecomment-143109739
+  it('should compose w/ other compositions', function() {
+    var called = [];
+
+    return compose([
+        compose([
+            (ctx, next) => {
+                called.push(1)
+                return next()
+            },
+            (ctx, next) => {
+                called.push(2)
+                return next()
+            }
+        ]),
+        (ctx, next) => {
+            called.push(3)
+            return next()
+        }
+    ])({}).then(() => assert.deepEqual(called, [1, 2, 3]))
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -201,4 +201,13 @@ describe('Koa Compose', function(){
         }
     ])({}).then(() => assert.deepEqual(called, [1, 2, 3]))
   })
+
+  it('should throw if next() is called multiple times', function() {
+    return compose([
+      co.wrap(function* (ctx, next) {
+        yield next()
+        yield next()
+      })
+    ])({}).then(() => {throw new Error('boom')}, err => {})
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -214,51 +214,6 @@ describe('Koa Compose', function(){
     })
   })
 
-  it('should throw if next() is called multiple times #2', function() {
-    return compose([
-      co.wrap(function* (ctx, next) {
-        yield ctx.next()
-        yield ctx.next()
-      }),
-      co.wrap(function* (ctx) {
-
-      })
-    ])({}).then(() => {
-      throw new Error('boom')
-    }, err => {
-      assert(/multiple times/.test(err.message))
-    })
-  })
-
-  it('should support ctx.next().then()', function(){
-    var arr = [];
-    var stack = [];
-
-    stack.push(function *(ctx){
-      arr.push(1);
-      arr.push(2);
-      yield ctx.next();
-      arr.push(7);
-      arr.push(8);
-    })
-
-    stack.push(function *(ctx){
-      arr.push(3);
-      yield ctx.next();
-      arr.push(6);
-    })
-
-    stack.push(function *(ctx){
-      arr.push(4);
-      yield ctx.next();
-      arr.push(5);
-    })
-
-    return compose(stack.map(co.wrap))({}).then(function () {
-      arr.should.eql([1, 2, 3, 4, 5, 6, 7, 8]);
-    })
-  })
-
   it('should return a valid middleware', function () {
     var val = 0
     compose([
@@ -279,15 +234,5 @@ describe('Koa Compose', function(){
     ])({}).then(function () {
       val.should.equal(3)
     })
-  })
-
-  it('should expose next on the context', function () {
-    var stack = [];
-
-    stack.push(function (context, next) {
-      context.next.should.equal(next)
-    })
-
-    return compose(stack.map(co.wrap))({})
   })
 })


### PR DESCRIPTION
goal is to be able to do:

```js
app.use(async ({request, response}, next) => {
  response.body = await somethingAsynchronous()
  await next()
})
```

TODO:

- [x] guard against multiple `next()` calls
- [ ] [standard](https://www.npmjs.com/package/standard)ize because the styling is over the place
- [ ] squash and merge