### PR TITLE
expose next on context

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function tryCatch(fn, ctx, next) {
 
 function middlewareReducer(next, mw) {
   return function(ctx, nextFn) {
-    ctx.next = next && function () { return next(ctx) }
+    ctx.next = next && function () { return next(ctx, nextFn) }
       || nextFn
       || noop
     return tryCatch(mw, ctx, ctx.next)

--- a/test/test.js
+++ b/test/test.js
@@ -179,6 +179,28 @@ describe('Koa Compose', function(){
     })
   })
 
+  it('should return a valid middleware', function () {
+    var val = 0
+    compose([
+      compose([
+        (ctx, next) => {
+          val++
+          return next()
+        },
+        (ctx, next) => {
+          val++
+          return next()
+        }
+      ]),
+      (ctx, next) => {
+        val++
+        return next()
+      }
+    ])({}).then(function () {
+      val.should.equal(3)
+    })
+  })
+
   it('should expose next on the context', function () {
     var stack = [];
 

--- a/test/test.js
+++ b/test/test.js
@@ -174,9 +174,18 @@ describe('Koa Compose', function(){
 
     return compose(stack.map(co.wrap))({}).then(function () {
       throw 'promise was not rejected'
-    })
-    .catch(function (e) {
+    }).catch(function (e) {
       e.should.be.instanceof(Error)
     })
+  })
+
+  it('should expose next on the context', function () {
+    var stack = [];
+
+    stack.push(function (context, next) {
+      context.next.should.equal(next)
+    })
+
+    return compose(stack.map(co.wrap))({})
   })
 })


### PR DESCRIPTION
So now we can

```javascript
app.use(async ({request, response, next }) => {
  //...
})
```

I also re-arranged a bit creating all the closures initially. Which will stop a large(ish) one from being created every request. 