### PR TITLE
Wrap mw w/ all provided wrappers from mw._wrappers

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,10 @@ function compose (middleware) {
     function dispatch (i) {
       if (i <= index) return Promise.reject(new Error('next() called multiple times'))
       index = i
-      const fn = middleware[i] || next
+      let fn = middleware[i] || next
       if (!fn) return Promise.resolve()
+      if (fn._wrapper && Array.isArray(fn._wrapper) && fn._wrapper.length)
+        fn = fn._wrappers.foreach((wrapper) => { fn = wrapper(fn) })
       try {
         return Promise.resolve(fn(context, function next () {
           return dispatch(i + 1)

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function compose (middleware) {
       index = i
       let fn = middleware[i] || next
       if (!fn) return Promise.resolve()
-      if (fn._wrapper && Array.isArray(fn._wrapper) && fn._wrapper.length) {
+      if (fn._wrappers && Array.isArray(fn._wrappers) && fn._wrappers.length) {
         fn = fn._wrappers.foreach((wrapper) => { fn = wrapper(fn) })
       }
       try {

--- a/index.js
+++ b/index.js
@@ -37,11 +37,8 @@ function compose (middleware) {
     function dispatch (i) {
       if (i <= index) return Promise.reject(new Error('next() called multiple times'))
       index = i
-      let fn = middleware[i] || next
+      const fn = wrap(middleware[i]) || next
       if (!fn) return Promise.resolve()
-      if (fn._wrappers && Array.isArray(fn._wrappers) && fn._wrappers.length) {
-        fn = fn._wrappers.foreach((wrapper) => { fn = wrapper(fn) })
-      }
       try {
         return Promise.resolve(fn(context, function next () {
           return dispatch(i + 1)
@@ -51,4 +48,22 @@ function compose (middleware) {
       }
     }
   }
+}
+
+/**
+ * composes a wrapped middleware using middleware._wrappers
+ *
+ * @param {Function} middleware
+ * @return {Function} composed
+ * @api public
+ */
+
+function wrap (middleware) {
+  if (!middleware) return false
+  if (!middleware._wrappers) return middleware
+  if (!Array.isArray(middleware._wrappers)) throw new TypeError('._wrappers must be an array')
+  if (!middleware._wrappers.length) return middleware
+  const wrappers = middleware._wrappers
+  delete middleware._wrappers
+  return compose([...wrappers, middleware])
 }

--- a/index.js
+++ b/index.js
@@ -39,8 +39,9 @@ function compose (middleware) {
       index = i
       let fn = middleware[i] || next
       if (!fn) return Promise.resolve()
-      if (fn._wrapper && Array.isArray(fn._wrapper) && fn._wrapper.length)
+      if (fn._wrapper && Array.isArray(fn._wrapper) && fn._wrapper.length) {
         fn = fn._wrappers.foreach((wrapper) => { fn = wrapper(fn) })
+      }
       try {
         return Promise.resolve(fn(context, function next () {
           return dispatch(i + 1)


### PR DESCRIPTION
Try 3456.

This adds a dependency by checking for wrappers at `middleware._wrappers`.
This solves a few things. 3rd party authors need not to necessarily do any change.

Consumers can "solve" this by appending `._wrappers` manually if needed:

``` js
const myMw = async (ctx, next) => { /* ... */ }
myMw._wrappers([wrapper1, wrapper2])
```

There's no signature change for `function compose()`, and no weird circular dependency from either Koa or its `context`.

**Optional**
If we want, Koa can now extend `koa/Application.use` with an optional options argument, to be consumed as following:

``` js
app.use(mw, {
  name: 'MyMiddleware', // or manually `mw._name = 'MyMiddleware`
  wrappers: true, // wraps using `this.wrappers`
  // or negate
  wrappers: false, // default true
  // or for a specific use-case, such as @PlasmaPower's pet peeve to extract auto convert
  // into a wrapper
  wrappers: [wrapper1, wrapper2, convert]
})
```

Or manually, because `koa-router` don't implement this yet:

``` js
let myMw = module.exports =  async (ctx, next) => {
  // ...
}

myMw._name = 'MyMiddleware'
myMw._wrappers = [wrapper1, wrapper2, convert]
```

Accompanied PR to Koa in a second.
Edit: https://github.com/koajs/koa/pull/718 for Koa implementation (without the optional stuff)
