### PR TITLE
improve compose logic.

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -13,7 +13,7 @@ suite('compose', () => {
     return logic().then(next).then(logic)
   }
 
-  for (let exp = 0; exp <= 10; exp++) {
+  for (let exp = 0; exp <= 13; exp++) {
     const count = Math.pow(2, exp)
     const arr = []
     for (let i = 0; i < count; i++) {

--- a/index.js
+++ b/index.js
@@ -20,29 +20,51 @@ module.exports = compose
 
 function compose (middleware) {
   if (!Array.isArray(middleware)) throw new TypeError('Middleware stack must be an array!')
+
+  const composer = new Composer(null)
+  let nextComposer = composer
   for (const fn of middleware) {
     if (typeof fn !== 'function') throw new TypeError('Middleware must be composed of functions!')
+    nextComposer = nextComposer.addNext(fn)
   }
+  // a placehold composer for lastFn
+  nextComposer.addNext(null)
 
   /**
    * @param {Object} context
+   * @param {Function} lastFn
    * @return {Promise}
    * @api public
    */
+  return function (context, lastFn) {
+    return composer.nextFn(context, lastFn || null)()
+  }
+}
 
-  return function (context, next) {
-    // last called middleware #
-    let index = -1
-    return dispatch(0)
-    function dispatch (i) {
-      if (i <= index) return Promise.reject(new Error('next() called multiple times'))
-      index = i
-      const fn = middleware[i] || next
+class Composer {
+  constructor (fn) {
+    this.fn = fn
+    this.next = null
+  }
+
+  addNext (fn) {
+    this.next = new Composer(fn)
+    return this.next
+  }
+
+  nextFn (context, lastFn) {
+    let called = false
+    let composer = this.next
+
+    return function next () {
+      if (called) return Promise.reject(new Error('next() called multiple times'))
+      called = true
+      if (!composer) return Promise.resolve()
+      // if composer.fn not exists, it is the placehold composer
+      let fn = composer.fn || lastFn
       if (!fn) return Promise.resolve()
       try {
-        return Promise.resolve(fn(context, function next () {
-          return dispatch(i + 1)
-        }))
+        return Promise.resolve(fn(context, composer.nextFn(context, lastFn)))
       } catch (err) {
         return Promise.reject(err)
       }

--- a/test/test.js
+++ b/test/test.js
@@ -315,4 +315,22 @@ describe('Koa Compose', function () {
       assert.equal(fn, fn1)
     }
   })
+
+  it('should not enter an infinite loop #60', function () {
+    var ctx = {
+      middleware: 0,
+      next: 0
+    }
+    var middleware = [function (ctx, next) {
+      ctx.middleware++
+      return next()
+    }]
+
+    return compose(middleware)(ctx, function (ctx, next) {
+      ctx.next++
+      return next()
+    }).then(function () {
+      ctx.should.eql({middleware: 1, next: 1})
+    })
+  })
 })


### PR DESCRIPTION
**branch composer:**

``` sh
compose
114,158 op/s » (fn * 1)
64,464 op/s » (fn * 2)
33,850 op/s » (fn * 4)
16,501 op/s » (fn * 8)
8,891 op/s » (fn * 16)
4,502 op/s » (fn * 32)
2,214 op/s » (fn * 64)
1,079 op/s » (fn * 128)
574 op/s » (fn * 256)
273 op/s » (fn * 512)
136 op/s » (fn * 1024)
63 op/s » (fn * 2048)
27 op/s » (fn * 4096)
11 op/s » (fn * 8192)


Suites:  1
Benches: 14
Elapsed: 32,302.83 ms
```

**banch next-57-iterator:**

```
compose
85,536 op/s » (fn * 1)
45,344 op/s » (fn * 2)
21,636 op/s » (fn * 4)
9,103 op/s » (fn * 8)
4,284 op/s » (fn * 16)
2,626 op/s » (fn * 32)
1,392 op/s » (fn * 64)
671 op/s » (fn * 128)
339 op/s » (fn * 256)
164 op/s » (fn * 512)
77 op/s » (fn * 1024)
36 op/s » (fn * 2048)
14 op/s » (fn * 4096)
6 op/s » (fn * 8192)


Suites:  1
Benches: 14
Elapsed: 44,373.84 ms
```
