### PR TITLE
Check return value of middleware to make sure its a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,9 @@ function compose (middleware) {
         if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
           return result
         }
+        if (result === undefined) {
+          return Promise.resolve();
+        }
         throw new TypeError('Middleware must return a Promise');
       } catch (err) {
         return Promise.reject(err)

--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ function compose (middleware) {
    */
 
   return function (context, next) {
+    if (next && typeof next !== 'function') {
+      throw new TypeError('Next must be a function when specified')
+    }
     // last called middleware #
     let index = -1
     return dispatch(0)

--- a/index.js
+++ b/index.js
@@ -41,9 +41,13 @@ function compose (middleware) {
       if (i === middleware.length) fn = next
       if (!fn) return Promise.resolve()
       try {
-        return Promise.resolve(fn(context, function next () {
+        const result = fn(context, function next () {
           return dispatch(i + 1)
-        }))
+        })
+        if (typeof result.then === 'function') {
+          return result
+        }
+        throw new TypeError('Middleware must return a Promise');
       } catch (err) {
         return Promise.reject(err)
       }

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function compose (middleware) {
         const result = fn(context, function next () {
           return dispatch(i + 1)
         })
-        if (typeof result.then === 'function') {
+        if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
           return result
         }
         throw new TypeError('Middleware must return a Promise');

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function compose (middleware) {
    */
 
   return function (context, next) {
-    if (next && typeof next !== 'function') {
+    if (next !== undefined && typeof next !== 'function') {
       throw new TypeError('Next must be a function when specified')
     }
     // last called middleware #
@@ -51,9 +51,9 @@ function compose (middleware) {
           return result
         }
         if (result === undefined) {
-          return Promise.resolve();
+          return Promise.resolve()
         }
-        throw new TypeError('Middleware must return a Promise');
+        throw new TypeError('Middleware must return a Promise')
       } catch (err) {
         return Promise.reject(err)
       }

--- a/test/test.js
+++ b/test/test.js
@@ -335,4 +335,17 @@ describe('Koa Compose', function () {
       ctx.should.eql({ middleware: 1, next: 1 })
     })
   })
+
+  it('should allow not calling next', () => {
+    const middleware = [(ctx) => {
+      ctx.middleware++
+    }]
+    const ctx = {
+      middleware: 0
+    }
+
+    return compose(middleware)(ctx).then(() => {
+      ctx.should.eql({ middleware: 1 })
+    })
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -278,24 +278,16 @@ describe('Koa Compose', function () {
     })
   })
 
-  it('should return last return value', function () {
-    var stack = []
-
-    stack.push(function * (context, next) {
-      var val = yield next()
-      val.should.equal(2)
-      return 1
+  it('should throw if a middleware does not return a promise', function () {
+    var next = () => null
+    return compose([])({}, next)
+    .then(function () {
+      throw new Error('promise was not rejected')
+    })
+    .catch(function (e) {
+      e.should.be.instanceof(Error)
     })
 
-    stack.push(function * (context, next) {
-      var val = yield next()
-      val.should.equal(0)
-      return 2
-    })
-    var next = () => 0
-    return compose(stack.map(co.wrap))({}, next).then(function (val) {
-      val.should.equal(1)
-    })
   })
 
   it('should not affect the original middleware array', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -109,6 +109,17 @@ describe('Koa Compose', function () {
     return (err).should.be.instanceof(TypeError)
   })
 
+  it('should only accept functions for next', function () {
+    var err
+    var next = "Not  null, not a function"
+    try {
+      (compose([])({}, next)).should.throw()
+    } catch (e) {
+      err = e
+    }
+    return (err).should.be.instanceof(TypeError)
+  })
+
   it('should work when yielding at the end of the stack', function () {
     var stack = []
     var called = false

--- a/test/test.js
+++ b/test/test.js
@@ -111,7 +111,7 @@ describe('Koa Compose', function () {
 
   it('should only accept functions for next', function () {
     var err
-    var next = "Not  null, not a function"
+    var next = 'Not  null, not a function'
     try {
       (compose([])({}, next)).should.throw()
     } catch (e) {
@@ -298,7 +298,6 @@ describe('Koa Compose', function () {
     .catch(function (e) {
       e.should.be.instanceof(Error)
     })
-
   })
 
   it('should not affect the original middleware array', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -318,21 +318,10 @@ describe('Koa Compose', function () {
     }
   })
 
-  it('should not get stuck on the passed in next', () => {
-    const middleware = [(ctx, next) => {
-      ctx.middleware++
-      return next()
-    }]
-    const ctx = {
-      middleware: 0,
-      next: 0
-    }
-
-    return compose(middleware)(ctx, (ctx, next) => {
-      ctx.next++
-      return next()
-    }).then(() => {
-      ctx.should.eql({ middleware: 1, next: 1 })
+  it('does not call next with middleware parameters', () => {
+    return compose([])({}, (ctx, next) => {
+      assert.strictEqual(ctx, undefined)
+      assert.strictEqual(next, undefined)
     })
   })
 


### PR DESCRIPTION
I was tracking down a bug where I did a `return next` instead of `return next()`, which I was surprised to find didn't trigger an error at all.

So I added code to check the return value and raise an error if its not a `Promise`.

Which completely blew up the Koa test suite and I realized that code that is intentionally not calling `next` is usually returning `undefined`, so I added a check for that.  But that limits the usefulness of the error check.

Its hard to determine the difference between I forgot to process `next()` and I meant to not process `next()`.

I also experimented with re-using that promise instead of creating a new one.  Slightly slower.

Anyway, putting the experiment up here for comment.

next branch:
```
                      compose
         347,666 op/s » (fn * 1)
         131,735 op/s » (fn * 2)
          62,756 op/s » (fn * 4)
          29,906 op/s » (fn * 8)
          14,849 op/s » (fn * 16)
           7,325 op/s » (fn * 32)
           3,632 op/s » (fn * 64)
           1,803 op/s » (fn * 128)
             898 op/s » (fn * 256)
             444 op/s » (fn * 512)
             216 op/s » (fn * 1024)


  Suites:  1
  Benches: 11
  Elapsed: 18,501.79 ms
```
This PR:
```
                      compose
         337,992 op/s » (fn * 1)
         132,977 op/s » (fn * 2)
          62,053 op/s » (fn * 4)
          29,820 op/s » (fn * 8)
          14,687 op/s » (fn * 16)
           7,251 op/s » (fn * 32)
           3,553 op/s » (fn * 64)
           1,779 op/s » (fn * 128)
             887 op/s » (fn * 256)
             431 op/s » (fn * 512)
             221 op/s » (fn * 1024)


  Suites:  1
  Benches: 11
  Elapsed: 18,098.01 ms
```