### PR TITLE
Require middleware to return a promise with skipNext support [experimental]

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,9 @@ function compose (middleware) {
         if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
           return result
         }
+        if (result === undefined) {
+          return Promise.resolve();
+        }
         throw new TypeError('Middleware must return a Promise');
       } catch (err) {
         return Promise.reject(err)

--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ function compose (middleware) {
    */
 
   return function (context, next) {
+    if (next && typeof next !== 'function') {
+      throw new TypeError('Next must be a function when specified')
+    }
     // last called middleware #
     let index = -1
     return dispatch(0)

--- a/index.js
+++ b/index.js
@@ -9,47 +9,6 @@ const Promise = require('any-promise')
 module.exports = compose
 
 /**
- * Default skip function used when none is specified.
- *
- * @return {Promise}
- * @api public
- */
-
-function defaultSkip() {
-  return Promise.resolve()
-}
-
-/**
- * Call a middleware and ensure that a promise is always returned by 
- * transforming exceptions into rejected promises.
- *
- * @param {Function} middleware
- * @param {object} context
- * @param {Function} next
- * @param {Function} skipNext
- * @return {Promise}
- * @api public
- */
- 
-function callMiddleware(middleware, context, next, skip) {
-  try {
-    const result = middleware(context, next, skip)
-    if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
-      return result
-    }
-    if (result === undefined) {
-      if (middleware === skip) {
-        throw new Error('skipNext infinite loop detected');
-      }
-      return callMiddleware(skip, context);
-    }
-    throw new TypeError('Middleware must return a Promise')
-  } catch (err) {
-    return Promise.reject(err)
-  }
-}
-
-/**
  * Compose `middleware` returning
  * a fully valid middleware comprised
  * of all those which are passed.
@@ -81,6 +40,18 @@ function compose (middleware) {
     if (skipNext !== undefined && typeof skipNext !== 'function') {
       throw new TypeError('skipNext must be a function when specified')
     }
+    let hasTerminated = false;
+    const skipFn = () => {
+      if (hasTerminated) {
+        throw new Error('skipNext() called multiple times');
+      }
+      hasTerminated = true;
+      if (skipNext) {
+        return skipNext();
+      }
+      return Promise.resolve();
+    }
+    const terminate = next || skipFn
     // last called middleware #
     let lastCalled = -1
     return dispatch(0)
@@ -94,14 +65,25 @@ function compose (middleware) {
     function dispatch (i) {
       if (i <= lastCalled) return Promise.reject(new Error('next() called multiple times'))
       lastCalled = i
-      const nextFn = function next () {
-        return dispatch(i + 1)
+      try {
+        let result
+        let nextCalled = false;
+        if (i < middleware.length) {
+          const nextFn = function next () {
+            nextCalled = true;
+            return dispatch(i + 1)
+          }
+          result = middleware[i](context, nextFn, skipFn)
+        } else {
+          result = terminate()
+        }
+        if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
+          return result
+        }
+        throw new TypeError('Middleware must return a Promise')
+      } catch (err) {
+        return Promise.reject(err)
       }
-      const skipFn = skipNext === undefined ? defaultSkip: skipNext
-      let middlewareFn = middleware[i]
-      if (i === middleware.length) middlewareFn = next
-      if (middlewareFn === undefined) middlewareFn = skipFn
-      return callMiddleware(middlewareFn, context, nextFn, skipFn)
     } 
   }
 }

--- a/index.js
+++ b/index.js
@@ -41,9 +41,13 @@ function compose (middleware) {
       if (i === middleware.length) fn = next
       if (!fn) return Promise.resolve()
       try {
-        return Promise.resolve(fn(context, function next () {
+        const result = fn(context, function next () {
           return dispatch(i + 1)
-        }))
+        })
+        if (typeof result.then === 'function') {
+          return result
+        }
+        throw new TypeError('Middleware must return a Promise');
       } catch (err) {
         return Promise.reject(err)
       }

--- a/index.js
+++ b/index.js
@@ -40,37 +40,35 @@ function compose (middleware) {
     if (skipNext !== undefined && typeof skipNext !== 'function') {
       throw new TypeError('skipNext must be a function when specified')
     }
-    let hasTerminated = false;
+    let hasTerminated = false
     const skipFn = () => {
       if (hasTerminated) {
-        throw new Error('skipNext() called multiple times');
+        throw new Error('skipNext() called multiple times')
       }
-      hasTerminated = true;
+      hasTerminated = true
       if (skipNext) {
-        return skipNext();
+        return skipNext()
       }
-      return Promise.resolve();
+      return Promise.resolve()
     }
     const terminate = next || skipFn
     // last called middleware #
     let lastCalled = -1
     return dispatch(0)
-    
+
     /**
      * Dispatch to the i-th middleware in the composed stack, capturing
      * the state necessary to continue the process in the `next()` closure.
      * @param {Number} i
      */
-     
+
     function dispatch (i) {
       if (i <= lastCalled) return Promise.reject(new Error('next() called multiple times'))
       lastCalled = i
       try {
         let result
-        let nextCalled = false;
         if (i < middleware.length) {
           const nextFn = function next () {
-            nextCalled = true;
             return dispatch(i + 1)
           }
           result = middleware[i](context, nextFn, skipFn)
@@ -84,6 +82,6 @@ function compose (middleware) {
       } catch (err) {
         return Promise.reject(err)
       }
-    } 
+    }
   }
 }

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function compose (middleware) {
         const result = fn(context, function next () {
           return dispatch(i + 1)
         })
-        if (typeof result.then === 'function') {
+        if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
           return result
         }
         throw new TypeError('Middleware must return a Promise');

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function compose (middleware) {
    */
 
   return function (context, next) {
-    if (next && typeof next !== 'function') {
+    if (next !== undefined && typeof next !== 'function') {
       throw new TypeError('Next must be a function when specified')
     }
     // last called middleware #
@@ -51,9 +51,9 @@ function compose (middleware) {
           return result
         }
         if (result === undefined) {
-          return Promise.resolve();
+          return Promise.resolve()
         }
-        throw new TypeError('Middleware must return a Promise');
+        throw new TypeError('Middleware must return a Promise')
       } catch (err) {
         return Promise.reject(err)
       }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,47 @@ const Promise = require('any-promise')
 module.exports = compose
 
 /**
+ * Default skip function used when none is specified.
+ *
+ * @return {Promise}
+ * @api public
+ */
+
+function defaultSkip() {
+  return Promise.resolve()
+}
+
+/**
+ * Call a middleware and ensure that a promise is always returned by 
+ * transforming exceptions into rejected promises.
+ *
+ * @param {Function} middleware
+ * @param {object} context
+ * @param {Function} next
+ * @param {Function} skipNext
+ * @return {Promise}
+ * @api public
+ */
+ 
+function callMiddleware(middleware, context, next, skip) {
+  try {
+    const result = middleware(context, next, skip)
+    if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
+      return result
+    }
+    if (result === undefined) {
+      if (middleware === skip) {
+        throw new Error('skipNext infinite loop detected');
+      }
+      return callMiddleware(skip, context);
+    }
+    throw new TypeError('Middleware must return a Promise')
+  } catch (err) {
+    return Promise.reject(err)
+  }
+}
+
+/**
  * Compose `middleware` returning
  * a fully valid middleware comprised
  * of all those which are passed.
@@ -25,38 +66,42 @@ function compose (middleware) {
   }
 
   /**
+   * Middleware function representing composition of middleware stack
    * @param {Object} context
+   * @param {Function} next
+   * @param {Function} skipNext
    * @return {Promise}
    * @api public
    */
 
-  return function (context, next) {
+  return function (context, next, skipNext) {
     if (next !== undefined && typeof next !== 'function') {
       throw new TypeError('Next must be a function when specified')
     }
-    // last called middleware #
-    let index = -1
-    return dispatch(0)
-    function dispatch (i) {
-      if (i <= index) return Promise.reject(new Error('next() called multiple times'))
-      index = i
-      let fn = middleware[i]
-      if (i === middleware.length) fn = next
-      if (!fn) return Promise.resolve()
-      try {
-        const result = fn(context, function next () {
-          return dispatch(i + 1)
-        })
-        if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
-          return result
-        }
-        if (result === undefined) {
-          return Promise.resolve()
-        }
-        throw new TypeError('Middleware must return a Promise')
-      } catch (err) {
-        return Promise.reject(err)
-      }
+    if (skipNext !== undefined && typeof skipNext !== 'function') {
+      throw new TypeError('skipNext must be a function when specified')
     }
+    // last called middleware #
+    let lastCalled = -1
+    return dispatch(0)
+    
+    /**
+     * Dispatch to the i-th middleware in the composed stack, capturing
+     * the state necessary to continue the process in the `next()` closure.
+     * @param {Number} i
+     */
+     
+    function dispatch (i) {
+      if (i <= lastCalled) return Promise.reject(new Error('next() called multiple times'))
+      lastCalled = i
+      const nextFn = function next () {
+        return dispatch(i + 1)
+      }
+      const skipFn = skipNext === undefined ? defaultSkip: skipNext
+      let middlewareFn = middleware[i]
+      if (i === middleware.length) middlewareFn = next
+      if (middlewareFn === undefined) middlewareFn = skipFn
+      return callMiddleware(middlewareFn, context, nextFn, skipFn)
+    } 
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -335,4 +335,17 @@ describe('Koa Compose', function () {
       ctx.should.eql({ middleware: 1, next: 1 })
     })
   })
+
+  it('should allow not calling next', () => {
+    const middleware = [(ctx) => {
+      ctx.middleware++
+    }]
+    const ctx = {
+      middleware: 0
+    }
+
+    return compose(middleware)(ctx).then(() => {
+      ctx.should.eql({ middleware: 1 })
+    })
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -278,24 +278,16 @@ describe('Koa Compose', function () {
     })
   })
 
-  it('should return last return value', function () {
-    var stack = []
-
-    stack.push(function * (context, next) {
-      var val = yield next()
-      val.should.equal(2)
-      return 1
+  it('should throw if a middleware does not return a promise', function () {
+    var next = () => null
+    return compose([])({}, next)
+    .then(function () {
+      throw new Error('promise was not rejected')
+    })
+    .catch(function (e) {
+      e.should.be.instanceof(Error)
     })
 
-    stack.push(function * (context, next) {
-      var val = yield next()
-      val.should.equal(0)
-      return 2
-    })
-    var next = () => 0
-    return compose(stack.map(co.wrap))({}, next).then(function (val) {
-      val.should.equal(1)
-    })
   })
 
   it('should not affect the original middleware array', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -109,6 +109,17 @@ describe('Koa Compose', function () {
     return (err).should.be.instanceof(TypeError)
   })
 
+  it('should only accept functions for next', function () {
+    var err
+    var next = "Not  null, not a function"
+    try {
+      (compose([])({}, next)).should.throw()
+    } catch (e) {
+      err = e
+    }
+    return (err).should.be.instanceof(TypeError)
+  })
+
   it('should work when yielding at the end of the stack', function () {
     var stack = []
     var called = false

--- a/test/test.js
+++ b/test/test.js
@@ -111,7 +111,7 @@ describe('Koa Compose', function () {
 
   it('should only accept functions for next', function () {
     var err
-    var next = "Not  null, not a function"
+    var next = 'Not  null, not a function'
     try {
       (compose([])({}, next)).should.throw()
     } catch (e) {
@@ -298,7 +298,6 @@ describe('Koa Compose', function () {
     .catch(function (e) {
       e.should.be.instanceof(Error)
     })
-
   })
 
   it('should not affect the original middleware array', () => {


### PR DESCRIPTION
This is an implementation of the skipNext concept from #70.

This adds checks to middleware return values that ensures that middleware always returns a `Promise`.

The following is an error.  Any promise returned by `next` is lost. Upstream tasks will not properly wait for downstream tasks to complete.
```js
app.use((ctx, next) => next());
```
With this PR, koa-compose would catch this error.

In the case where we want to short circuit the middleware chain, a `skipNext` parameter is introduced
to indicate that we do NOT want to call `next`.
```js
app.use((ctx, next, skipNext) => return skipNext());
```

This is helpful to distinguish between the case of intentionally skipping the call to `next` and accidentally forgetting to call `next`.

This is also useful if we want to inject a return value at the top of our middleware chain and then have it
propagate back up.

For example, with this version of `koa-compose`, the Koa request handler could be changed to
```js
    const handleRequest = (req, res) => {
      res.statusCode = 404;
      const ctx = this.createContext(req, res);
      const onerror = err => ctx.onerror(err);
      onFinished(res, onerror);
      const skipNext = () => Promise.resolve(ctx.response)
      const next = skipNext
      fn(ctx, next, skipNext).then((response) => {
        if (!this.response.isPrototypeOf(response)) {
          throw new Error('Response object not received at the top of middleware chain')
        }
        respond(ctx)
      }).catch(onerror)
    };
```

Either `next` or `skipNext` can terminate the middleware chain.  In `handleRequest` the response
object is captured at the top of the chain as `next` and `skipNext`. Then, when the chain is terminated, the response object will bubble back up the chain as the return value of `next`. 

This response value could also be used by middleware as it bubbles up.  The following is valid middleware with the above `handleRequest` implementation and this PR.

```js
app.use(async (ctx, next) => {
  const response = await next()
  response.body = 'Hello Word'
  return response
});
```

Note that the return is required because without it, the error check in `handleRequest` will create a "Response object not received at the top of middleware chain" error.

Consider this erroneous code.  Because it is an async function, it always returns a `Promise`. However, it does not `await` on `next`, so upstream middleware cannot properly wait for downstream middleware to complete.
```js
app.use(async (ctx, next) => { next() })
```
With this PR and this `handleRequest` implementation, a "Response object not received at the top of middleware chain" error would be triggered.

A less strict, more backward compatible form is also possible.  If the middleware returns `undefined`, `skipNext` could be automatically called.  Thus the following prior example could be abbreviated as

```js
app.use(async (ctx, next) => {
  const response = await next()
  response.body = 'Hello Word'
});
```
This would lose the ability to detect failure to `await` in an `async` function and the check against calling `skipNext` multiple times would have to be removed.

It makes more sense to me to require the return and highlight the control flow along the return path.

If that's too much of a signature change for Koa, then I think the compatible version makes sense to help koa-compose be more useful as a general async middleware mechanism beyond Koa.