### PR TITLE
deps: removed any-promise as dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const Promise = require('any-promise')
-
 /**
  * Expose compositor.
  */

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   "files": [
     "index.js"
   ],
-  "dependencies": {
-    "any-promise": "^1.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "istanbul": "^0.4.2",
     "matcha": "^0.7.0",


### PR DESCRIPTION
Favour `global.Promise = require('custom-promise-impl')`

I guess this would be semver major if merged.

koa-compose is now dependency free because of it *(like it matters, but it looks cool)*.