### PR TITLE
test: switched from mocha to jest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 node_js:
 - 7
+- 8
 sudo: false
 language: node_js
 script:
   - npm run lint
-  - npm run test-travis
+  - npm run test
   - npm run bench
-  - npm i codecov
   - ./node_modules/.bin/codecov

--- a/package.json
+++ b/package.json
@@ -14,17 +14,16 @@
   "dependencies": {},
   "devDependencies": {
     "istanbul": "^0.4.2",
+    "jest": "^19.0.2",
     "matcha": "^0.7.0",
-    "mocha": "^3.1.2",
-    "should": "^2.0.0",
     "standard": "^9.0.1"
   },
   "scripts": {
     "bench": "matcha bench/bench.js",
     "lint": "standard index.js test/*.js",
-    "test": "mocha --require should --reporter spec",
-    "test-cov": "node ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --require should",
-    "test-travis": "node ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- --require should"
+    "test": "jest",
+    "test-cov": "node ./node_modules/.bin/istanbul cover ./node_modules/.bin/jest",
+    "test-travis": "node ./node_modules/.bin/istanbul cover ./node_modules/.bin/jest --coverage"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -13,17 +13,18 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "istanbul": "^0.4.2",
-    "jest": "^19.0.2",
+    "codecov": "^2.2.0",
+    "jest": "^20.0.4",
     "matcha": "^0.7.0",
-    "standard": "^9.0.1"
+    "standard": "^9.0.2"
   },
   "scripts": {
     "bench": "matcha bench/bench.js",
     "lint": "standard index.js test/*.js",
-    "test": "jest",
-    "test-cov": "node ./node_modules/.bin/istanbul cover ./node_modules/.bin/jest",
-    "test-travis": "node ./node_modules/.bin/istanbul cover ./node_modules/.bin/jest --coverage"
+    "test": "jest --forceExit --coverage"
+  },
+  "jest": {
+    "testEnvironment": "node"
   },
   "license": "MIT"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-/* eslint-env mocha */
+/* eslint-env jest */
 
 const compose = require('..')
 const assert = require('assert')
@@ -10,9 +10,9 @@ function wait (ms) {
 }
 
 describe('Koa Compose', function () {
-  it('should work', function () {
-    var arr = []
-    var stack = []
+  it('should work', async () => {
+    const arr = []
+    const stack = []
 
     stack.push(async (context, next) => {
       arr.push(1)
@@ -38,9 +38,8 @@ describe('Koa Compose', function () {
       arr.push(4)
     })
 
-    return compose(stack)({}).then(function () {
-      arr.should.eql([1, 2, 3, 4, 5, 6])
-    })
+    await compose(stack)({})
+    expect(arr).toEqual(expect.arrayContaining([1, 2, 3, 4, 5, 6]))
   })
 
   it('should be able to be called twice', () => {
@@ -77,38 +76,37 @@ describe('Koa Compose', function () {
 
     return fn(ctx1).then(() => {
       assert.deepEqual(out, ctx1.arr)
-
       return fn(ctx2)
     }).then(() => {
       assert.deepEqual(out, ctx2.arr)
     })
   })
 
-  it('should only accept an array', function () {
-    var err
+  it('should only accept an array', () => {
+    let err
     try {
-      (compose()).should.throw()
+      expect(compose()).toThrow()
     } catch (e) {
       err = e
     }
-    return (err).should.be.instanceof(TypeError)
+    return expect(err).toBeInstanceOf(TypeError)
   })
 
   it('should work with 0 middleware', function () {
     return compose([])({})
   })
 
-  it('should only accept middleware as functions', function () {
-    var err
+  it('should only accept middleware as functions', () => {
+    let err
     try {
-      (compose([{}])).should.throw()
+      expect(compose([{}])).toThrow()
     } catch (e) {
       err = e
     }
-    return (err).should.be.instanceof(TypeError)
+    return expect(err).toBeInstanceOf(TypeError)
   })
 
-  it('should work when yielding at the end of the stack', function () {
+  it('should work when yielding at the end of the stack', async () => {
     var stack = []
     var called = false
 
@@ -117,12 +115,11 @@ describe('Koa Compose', function () {
       called = true
     })
 
-    return compose(stack)({}).then(function () {
-      assert(called)
-    })
+    await compose(stack)({})
+    assert(called)
   })
 
-  it('should reject on errors in middleware', function () {
+  it('should reject on errors in middleware', () => {
     var stack = []
 
     stack.push(() => { throw new Error() })
@@ -132,46 +129,46 @@ describe('Koa Compose', function () {
         throw new Error('promise was not rejected')
       })
       .catch(function (e) {
-        e.should.be.instanceof(Error)
+        expect(e).toBeInstanceOf(Error)
       })
   })
 
-  it('should work when yielding at the end of the stack with yield*', function () {
+  it('should work when yielding at the end of the stack with yield*', () => {
     var stack = []
 
     stack.push(async (ctx, next) => {
       await next
     })
 
-    compose(stack)({})
+    return compose(stack)({})
   })
 
-  it('should keep the context', function () {
-    var ctx = {}
+  it('should keep the context', () => {
+    const ctx = {}
 
-    var stack = []
+    const stack = []
 
     stack.push(async (ctx2, next) => {
       await next()
-      ctx2.should.equal(ctx)
+      expect(ctx2).toEqual(ctx)
     })
 
     stack.push(async (ctx2, next) => {
       await next()
-      ctx2.should.equal(ctx)
+      expect(ctx2).toEqual(ctx)
     })
 
     stack.push(async (ctx2, next) => {
       await next()
-      ctx2.should.equal(ctx)
+      expect(ctx2).toEqual(ctx)
     })
 
     return compose(stack)(ctx)
   })
 
-  it('should catch downstream errors', function () {
-    var arr = []
-    var stack = []
+  it('should catch downstream errors', async () => {
+    const arr = []
+    const stack = []
 
     stack.push(async (ctx, next) => {
       arr.push(1)
@@ -188,16 +185,14 @@ describe('Koa Compose', function () {
     stack.push(async (ctx, next) => {
       arr.push(4)
       throw new Error()
-      // arr.push(5)
     })
 
-    return compose(stack)({}).then(function () {
-      arr.should.eql([1, 6, 4, 2, 3])
-    })
+    await compose(stack)({})
+    expect(arr).toEqual([1, 6, 4, 2, 3])
   })
 
-  it('should compose w/ next', function () {
-    var called = false
+  it('should compose w/ next', () => {
+    let called = false
 
     return compose([])({}, async () => {
       called = true
@@ -206,8 +201,8 @@ describe('Koa Compose', function () {
     })
   })
 
-  it('should handle errors in wrapped non-async functions', function () {
-    var stack = []
+  it('should handle errors in wrapped non-async functions', () => {
+    const stack = []
 
     stack.push(function () {
       throw new Error()
@@ -216,12 +211,12 @@ describe('Koa Compose', function () {
     return compose(stack)({}).then(function () {
       throw new Error('promise was not rejected')
     }).catch(function (e) {
-      e.should.be.instanceof(Error)
+      expect(e).toBeInstanceOf(Error)
     })
   })
 
   // https://github.com/koajs/compose/pull/27#issuecomment-143109739
-  it('should compose w/ other compositions', function () {
+  it('should compose w/ other compositions', () => {
     var called = []
 
     return compose([
@@ -242,7 +237,7 @@ describe('Koa Compose', function () {
     ])({}).then(() => assert.deepEqual(called, [1, 2, 3]))
   })
 
-  it('should throw if next() is called multiple times', function () {
+  it('should throw if next() is called multiple times', () => {
     return compose([
       async (ctx, next) => {
         await next()
@@ -255,9 +250,9 @@ describe('Koa Compose', function () {
     })
   })
 
-  it('should return a valid middleware', function () {
-    var val = 0
-    compose([
+  it('should return a valid middleware', () => {
+    let val = 0
+    return compose([
       compose([
         (ctx, next) => {
           val++
@@ -273,27 +268,28 @@ describe('Koa Compose', function () {
         return next()
       }
     ])({}).then(function () {
-      val.should.equal(3)
+      expect(val).toEqual(3)
     })
   })
 
-  it('should return last return value', function () {
-    var stack = []
+  it('should return last return value', () => {
+    const stack = []
 
     stack.push(async (context, next) => {
       var val = await next()
-      val.should.equal(2)
+      expect(val).toEqual(2)
       return 1
     })
 
     stack.push(async (context, next) => {
-      var val = await next()
-      val.should.equal(0)
+      const val = await next()
+      expect(val).toEqual(0)
       return 2
     })
-    var next = () => 0
+
+    const next = () => 0
     return compose(stack)({}, next).then(function (val) {
-      val.should.equal(1)
+      expect(val).toEqual(1)
     })
   })
 
@@ -329,7 +325,7 @@ describe('Koa Compose', function () {
       ctx.next++
       return next()
     }).then(() => {
-      ctx.should.eql({ middleware: 1, next: 1 })
+      expect(ctx).toEqual({ middleware: 1, next: 1 })
     })
   })
 })


### PR DESCRIPTION
This is a minimal "all green" effort for a mocha-to-jest conversion.

No stylistic changes were made unless it was easier to fulfil the test with said change (e.g. test 'should work' became an `async () => { ... }`). I assume @jonathanong wants to remove all `expect` (via jest now) and replace using `assert` only?

Changed `var` to `const` or `let` where practical.

~~I'm not sure how to fix scripts test-cov and test-travis correctly yet (unless it turns out to magically work in which case my untested-google-fu-and-deduction was awesome).~~

Fixes #76