### PR TITLE
Add recursive composition (semver-minor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 *.log
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 /**
  * Module dependencies.
  */
- 
+
 const { isArray } = Array
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 'use strict'
 
 /**
+ * Module dependencies.
+ */
+ 
+const { isArray } = Array
+
+/**
  * Expose compositor.
  */
 
@@ -17,9 +23,11 @@ module.exports = compose
  */
 
 function compose (middleware) {
-  if (!Array.isArray(middleware)) throw new TypeError('Middleware stack must be an array!')
+  if (!isArray(middleware)) throw new TypeError('Middleware stack must be an array!')
   for (const fn of middleware) {
-    if (typeof fn !== 'function') throw new TypeError('Middleware must be composed of functions!')
+    if (typeof fn !== 'function' && !isArray(fn)) {
+      throw new TypeError('Middleware must be composed of functions, or array of functions!')
+    }
   }
 
   /**
@@ -36,6 +44,7 @@ function compose (middleware) {
       if (i <= index) return Promise.reject(new Error('next() called multiple times'))
       index = i
       let fn = middleware[i]
+      if (isArray(fn)) fn = compose(fn)
       if (i === middleware.length) fn = next
       if (!fn) return Promise.resolve()
       try {

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ describe('Koa Compose', function () {
     it('should work', () => {
       const arr = []
       const stack = []
-      
+
       stack.push(async (ctx, next) => {
         arr.push(1)
         await wait(1)
@@ -22,7 +22,7 @@ describe('Koa Compose', function () {
         await wait(1)
         arr.push(8)
       })
-      
+
       stack.push([
         async (ctx, next) => {
           arr.push(2)
@@ -39,7 +39,7 @@ describe('Koa Compose', function () {
           arr.push(6)
         }
       ])
-      
+
       stack.push(async (ctx, next) => {
         arr.push(4)
         await wait(1)
@@ -47,15 +47,15 @@ describe('Koa Compose', function () {
         await wait(1)
         arr.push(5)
       })
-      
+
       return compose(stack)({}).then(function () {
         arr.should.eql([1, 2, 3, 4, 5, 6, 7, 8])
       })
     })
-    
+
     it('should be able to be called twice', () => {
       const stack = []
-      
+
       stack.push(async (context, next) => {
         context.arr.push(1)
         await wait(1)
@@ -63,7 +63,7 @@ describe('Koa Compose', function () {
         await wait(1)
         context.arr.push(8)
       })
-      
+
       stack.push([
         async (context, next) => {
           context.arr.push(2)
@@ -80,7 +80,7 @@ describe('Koa Compose', function () {
           context.arr.push(6)
         }
       ])
-      
+
       stack.push(async (context, next) => {
         context.arr.push(4)
         await wait(1)
@@ -88,7 +88,7 @@ describe('Koa Compose', function () {
         await wait(1)
         context.arr.push(5)
       })
-      
+
       const fn = compose(stack)
       const ctx1 = { arr: [] }
       const ctx2 = { arr: [] }
@@ -101,7 +101,7 @@ describe('Koa Compose', function () {
         assert.deepEqual(out, ctx2.arr)
       })
     })
-    
+
     it('should throw if next() is called multiple times within recursion', function () {
       return compose([[
         async (ctx, next) => {
@@ -115,7 +115,7 @@ describe('Koa Compose', function () {
       })
     })
   })
-  
+
   it('should work', function () {
     var arr = []
     var stack = []


### PR DESCRIPTION
This is my take on the "wrapper hook/talk". It's minimally invasive.

The idea is to follow this up with:
  * koajs/koa:`Application.use()` accepts arrays with middleware, e.g. `app.use([mw1, mw2])`.
  * Optional: [koajs/koa:`Application.wrap()`] to globally wrap all `this.middleware` with whatever's inside `this.wrappers` with a simple map returning `[[wrapper1, mw], [wrapper1, mw2]]`.

As far as I can foresee, this should be unrestrictive enough for developers to be creative as one see fit, simple e.g:
```js
// stupid example
const wrappers = []
const wrapMiddleware = mw => {
  if (process.env.DEBUG_MIDDLEWARE) {
    return [...wrappers, mw]
  }
  return mw
}

...

const compress = require('koa-compress')
app.use(wrapMiddleware(compress()))
```

Related issues:
koajs/compose: https://github.com/koajs/compose/issues/6
koajs/koa: https://github.com/koajs/koa/issues/219

Related PRs:
koajs/compose: https://github.com/koajs/compose/pull/52
koajs/compose: https://github.com/koajs/compose/pull/53
koajs/koa: https://github.com/koajs/koa/pull/707
koajs/koa: https://github.com/koajs/koa/pull/694 *introduces `context.wrappers`, but I personally would enjoy context not being part of the solution.*