### PR TITLE
Allow pure functions by passing context

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,16 +31,16 @@ function compose (middleware) {
   return function (context, next) {
     // last called middleware #
     let index = -1
-    return dispatch(0)
-    function dispatch (i) {
+    return dispatch(0, context)
+    function dispatch (i, ctx) {
       if (i <= index) return Promise.reject(new Error('next() called multiple times'))
       index = i
       let fn = middleware[i]
       if (i === middleware.length) fn = next
-      if (!fn) return Promise.resolve()
+      if (!fn) return Promise.resolve(ctx)
       try {
-        return Promise.resolve(fn(context, function next () {
-          return dispatch(i + 1)
+        return Promise.resolve(fn(ctx, function next (_ctx = ctx) {
+          return dispatch(i + 1, _ctx)
         }))
       } catch (err) {
         return Promise.reject(err)

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ function compose (middleware) {
     // last called middleware #
     let index = -1
     return dispatch(0, context)
-    function dispatch (i, ctx) {
+    function dispatch (i, ctx = context) {
+      context = ctx
       if (i <= index) return Promise.reject(new Error('next() called multiple times'))
       index = i
       let fn = middleware[i]

--- a/test/test.js
+++ b/test/test.js
@@ -348,4 +348,29 @@ describe('Koa Compose', function () {
       expect(ctx).toEqual({ middleware: 1, next: 1 })
     })
   })
+
+  it('should work with pure functions', async () => {
+    const stack = []
+
+    stack.push(async (ctx, next) => {
+      const result = await next({ a: 1 })
+      expect(result).toBe(undefined)
+      return { done: 'ok' }
+    })
+
+    stack.push(async (ctx, next) => {
+      const result = await next({ b: ctx.a + 1 })
+      expect(result).toEqual({ c: 3 })
+    })
+
+    stack.push(async (ctx, next) => {
+      const result = await next({ c: ++ctx.b })
+      expect(result).toEqual({ c: 3 })
+      return result
+    })
+
+    const context = Object.freeze({})
+    const result = await compose(stack)(context)
+    expect(result).toEqual({ done: 'ok' })
+  })
 })


### PR DESCRIPTION
As a composition utility, there are use cases beyond koa middleware. In some cases it's desirable to write pure middleware functions. This PR adds support for such pure functions.