### PR TITLE
improve: reduce stack trace by removing useless function call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ node_js:
 - 7
 - 8
 - 9
+- 10 
 sudo: false
 language: node_js
 script:

--- a/index.js
+++ b/index.js
@@ -39,9 +39,7 @@ function compose (middleware) {
       if (i === middleware.length) fn = next
       if (!fn) return Promise.resolve()
       try {
-        return Promise.resolve(fn(context, function next () {
-          return dispatch(i + 1)
-        }))
+        return Promise.resolve(fn(context, dispatch.bind(null, i + 1)));
       } catch (err) {
         return Promise.reject(err)
       }


### PR DESCRIPTION
On my computer with Node 8.11.1

Before

```
                      compose
       1,283,509 op/s » (fn * 1)
         631,856 op/s » (fn * 2)
         323,821 op/s » (fn * 4)
         170,790 op/s » (fn * 8)
          86,148 op/s » (fn * 16)
          44,432 op/s » (fn * 32)
          21,890 op/s » (fn * 64)
          11,004 op/s » (fn * 128)
           5,523 op/s » (fn * 256)
           2,671 op/s » (fn * 512)
           1,294 op/s » (fn * 1024)


  Suites:  1
  Benches: 11
  Elapsed: 17,812.50 ms
```

After

```
                      compose
       1,306,215 op/s » (fn * 1)
         683,205 op/s » (fn * 2)
         352,461 op/s » (fn * 4)
         181,936 op/s » (fn * 8)
          93,017 op/s » (fn * 16)
          47,060 op/s » (fn * 32)
          23,650 op/s » (fn * 64)
          11,906 op/s » (fn * 128)
           5,858 op/s » (fn * 256)
           2,858 op/s » (fn * 512)
           1,383 op/s » (fn * 1024)


  Suites:  1
  Benches: 11
  Elapsed: 18,720.14 ms

```