### PR TITLE
feature: flatten passed array before compose

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ $ npm install koa-compose
 
 ## API
 
-### compose([a, b, c, ...])
+### compose([a, [b, c,] ...])
 
   Compose the given middleware and return middleware.
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@
 
 module.exports = compose
 
+function flatten (arr) {
+  return arr.reduce((acc, next) => acc.concat(Array.isArray(next) ? flatten(next) : next), [])
+}
+
 /**
  * Compose `middleware` returning
  * a fully valid middleware comprised
@@ -18,6 +22,7 @@ module.exports = compose
 
 function compose (middleware) {
   if (!Array.isArray(middleware)) throw new TypeError('Middleware stack must be an array!')
+  middleware = flatten(middleware)
   for (const fn of middleware) {
     if (typeof fn !== 'function') throw new TypeError('Middleware must be composed of functions!')
   }

--- a/test/test.js
+++ b/test/test.js
@@ -348,4 +348,43 @@ describe('Koa Compose', function () {
       expect(ctx).toEqual({ middleware: 1, next: 1 })
     })
   })
+
+  it('should flatten nested arrays ', async () => {
+    const middleware = [
+      (ctx, next) => { return ctx.middleware++, next() },
+      [
+        (ctx, next) => { return ctx.middleware++, next() },
+        (ctx, next) => { return ctx.middleware++, next() }
+      ],
+      (ctx, next) => { return ctx.middleware++, next() },
+    ]
+
+    const ctx = {
+      middleware: 0
+    }
+
+    await compose(middleware)(ctx, (ctx, next) => next()).then(() => {
+      expect(ctx).toEqual({ middleware: 4 })
+    })
+  })
+
+  it('should flatten and retain mw order', async () => {
+    const order = []
+    const middleware = [
+      (ctx, next) => { return order.push(1), next() },
+      [
+        (ctx, next) => { return order.push(2), next() },
+        (ctx, next) => { return order.push(3), next() },
+        [
+          (ctx, next) => { return order.push(4), next() },
+          (ctx, next) => { return order.push(5), next() }
+        ]
+      ],
+      (ctx, next) => { return order.push(6), next() },
+    ]
+
+    await compose(middleware)({}, (ctx, next) => next()).then(() => {
+      expect(order).toEqual([1, 2, 3, 4, 5, 6])
+    })
+  })
 })


### PR DESCRIPTION
This is step one to simplify koajs/koa#Application.use.
This is related to https://github.com/koajs/koa/pull/1153