### PR TITLE
add the catch method

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = compose
  * @api public
  */
 
-function compose (middleware) {
+function compose(middleware) {
+  const _this = this;
   if (!Array.isArray(middleware)) throw new TypeError('Middleware stack must be an array!')
   for (const fn of middleware) {
     if (typeof fn !== 'function') throw new TypeError('Middleware must be composed of functions!')
@@ -32,8 +33,10 @@ function compose (middleware) {
     // last called middleware #
     let index = -1
     return dispatch(0)
-    function dispatch (i) {
-      if (i <= index) return Promise.reject(new Error('next() called multiple times'))
+    function dispatch(i) {
+      if (i <= index) return Promise.reject(new Error('next() called multiple times')).catch(function (err) {
+        _this.emit('error', err)
+      })
       index = i
       let fn = middleware[i]
       if (i === middleware.length) fn = next


### PR DESCRIPTION
If you do not add the catch method, when calling the next method multiple times, for example like this `app.use((ctx, next) => {
  next();
  next();
})` 

,and an UnhandledPromiseRejectionWarning  is reported like this 

`(node:5224) UnhandledPromiseRejectionWarning: Error: next() called multiple times
    at dispatch (/Users/mac/Desktop/interview2/node_modules/koa-compose/index.js:36:45)
    at /Users/mac/Desktop/interview2/koa-lesson/1.server.js:30:3
    at dispatch (/Users/mac/Desktop/interview2/node_modules/koa-compose/index.js:42:32)
    at /Users/mac/Desktop/interview2/node_modules/koa-compose/index.js:34:12
    at Application.handleRequest (/Users/mac/Desktop/interview2/node_modules/koa/lib/application.js:166:12)
    at Server.handleRequest (/Users/mac/Desktop/interview2/node_modules/koa/lib/application.js:148:19)
    at Server.emit (events.js:223:5)
    at parserOnIncoming (_http_server.js:748:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:17)
(node:5224) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 7)`

this is not user-friendly，so I suggest to add the catch method. Hope to adopt it，thanks.

and modify the calling of the compose function in Application.js file,
`

    const fn = compose.call(this, this.middleware);

   `
[https://github.com/koajs/koa/pull/1450](url)





