### PR TITLE
Reworked to catch broken promise chains

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,7 @@ const composeSlim = (middleware) => async (ctx, next) => {
  */
 
 const compose = (middleware) => {
-  const isProduction = process.env.NODE_ENV === 'production'
-  if (isProduction) return composeSlim(middleware)
+  if (process.env.NODE_ENV === 'production') return composeSlim(middleware)
 
   if (!Array.isArray(middleware)) throw new TypeError('Middleware stack must be an array!')
   for (const fn of middleware) {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const composeSlim = (middleware) => async (ctx, next) => {
     if (!fn) return
     return await fn(ctx, dispatch(i + 1))
   }
-  return dispatch(0).call()
+  return dispatch(0)()
 }
 
 /**
@@ -27,11 +27,13 @@ const composeSlim = (middleware) => async (ctx, next) => {
 
 const compose = (...middleware) => {
   const funcs = middleware.flat()
-  if (process.env.NODE_ENV === 'production') return composeSlim(middleware)
 
   for (const fn of funcs) {
     if (typeof fn !== 'function') throw new TypeError('Middleware must be composed of functions!')
   }
+
+  if (process.env.NODE_ENV === 'production') return composeSlim(funcs)
+
   return async (ctx, next) => {
     const dispatch = async (i) => {
       const fn = i === funcs.length

--- a/test/test.js
+++ b/test/test.js
@@ -323,10 +323,6 @@ function testBaseFunctionality() {
 }
 
 function testDevErrors() {
-  it('should only accept an array', () => {
-    expect(() => compose()).toThrow(TypeError)
-  })
-
   it('should only accept middleware as functions', () => {
     expect(() => compose([{}])).toThrow(TypeError)
   })


### PR DESCRIPTION
To address the issue outlined in #74 and the original ticket in the koa repo, I've refactored the recursion implementation to make it easier to keep track of whether or not next hasn't resolved.
The fundamental thing I've done is to add a proxy for the next middleware that will note when the next dispatch call returns. If any given middleware calls next and resolves before it does we throw an error. Additionally I've stripped out all of the safeguards in production to slim the implementation even more.
In production it won't be dissimilar to how things are already implemented. In development though, there will be an increase in memory footprint as, in addition to more variables, there will be an extra stack frame per middleware. 