### PR TITLE
Use rest params

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,14 @@ module.exports = compose
  * a fully valid middleware comprised
  * of all those which are passed.
  *
- * @param {Array} middleware
+ * @param {...(Array | Function)} middleware
  * @return {Function}
  * @api public
  */
 
-function compose (middleware) {
-  if (!Array.isArray(middleware)) throw new TypeError('Middleware stack must be an array!')
-  for (const fn of middleware) {
+function compose (...middleware) {
+  const funcs = middleware.flat()
+  for (const fn of funcs) {
     if (typeof fn !== 'function') throw new TypeError('Middleware must be composed of functions!')
   }
 
@@ -35,8 +35,8 @@ function compose (middleware) {
     function dispatch (i) {
       if (i <= index) return Promise.reject(new Error('next() called multiple times'))
       index = i
-      let fn = middleware[i]
-      if (i === middleware.length) fn = next
+      let fn = funcs[i]
+      if (i === funcs.length) fn = next
       if (!fn) return Promise.resolve()
       try {
         return Promise.resolve(fn(context, dispatch.bind(null, i + 1)))

--- a/test/test.js
+++ b/test/test.js
@@ -111,7 +111,7 @@ describe('Koa Compose', function () {
   })
 
   it('should only accept middleware as functions', () => {
-    const badTypes = [1, true, 'string', {}, undefined, Symbol()];
+    const badTypes = [1, true, 'string', {}, undefined, Symbol('test')];
     [...badTypes, []].forEach((badType) => {
       expect(() => compose([badType])).toThrow(TypeError)
     })

--- a/test/test.js
+++ b/test/test.js
@@ -86,10 +86,6 @@ describe('Koa Compose', function () {
     })
   })
 
-  it('should only accept an array', () => {
-    expect(() => compose()).toThrow(TypeError)
-  })
-
   it('should create next functions that return a Promise', function () {
     const stack = []
     const arr = []
@@ -107,11 +103,21 @@ describe('Koa Compose', function () {
   })
 
   it('should work with 0 middleware', function () {
-    return compose([])({})
+    return Promise.all([
+      compose()({}),
+      compose([])({}),
+      compose([], [])({})
+    ])
   })
 
   it('should only accept middleware as functions', () => {
-    expect(() => compose([{}])).toThrow(TypeError)
+    const badTypes = [1, true, 'string', {}, undefined, Symbol()];
+    [...badTypes, []].forEach((badType) => {
+      expect(() => compose([badType])).toThrow(TypeError)
+    })
+    badTypes.forEach((badType) => {
+      expect(() => compose(badType)).toThrow(TypeError)
+    })
   })
 
   it('should work when yielding at the end of the stack', async () => {


### PR DESCRIPTION
This is an implementation of what was outlined in #63.
Super simple but it does require dropping support for node <v11.0.0.